### PR TITLE
Fix parameter checking logic error in tokenize

### DIFF
--- a/android/sqlite3_android.cpp
+++ b/android/sqlite3_android.cpp
@@ -267,7 +267,7 @@ static void tokenize(sqlite3_context * context, int argc, sqlite3_value ** argv)
     int useTokenIndex = 0;
     int useDataTag = 0;
 
-    if (!(argc >= 4 || argc <= 6)) {
+    if (!(argc >= 4 && argc <= 6)) {
         ALOGE("Tokenize requires 4 to 6 arguments");
         sqlite3_result_null(context);
         return;


### PR DESCRIPTION
Tokenize requires 4 to 6 arguments. If this condition is not met,
the program will return. But the judgment logic is always false.
It should to change the '||' to '&&' operation.

Bug: none
Test: sqlite unit tests

Change-Id: Id4238ee2ac0b8f3fde1eedaa09d5340b5937fde1
Signed-off-by: Jizhong Wang <wangjizhong@huawei.com>
Signed-off-by: mydongistiny <jaysonedson@gmail.com>